### PR TITLE
Creation of New Roles - create-testpmd, ovs-mq-bond

### DIFF
--- a/perf/ovs-mq-bond.yml
+++ b/perf/ovs-mq-bond.yml
@@ -1,0 +1,20 @@
+- hosts: dut_bond
+  vars:
+    datapath: dpdk
+
+  roles:
+    - ovs-base
+    - ovs-bond
+    - ovs-mq-bond
+    - create-testpmd
+
+- hosts: tgen_bond
+  vars:
+    datapath: dpdk
+  roles:
+    - role: trex
+      trex_opts: -c 20
+
+    - role: trex-ndr
+      profile: multi
+      expected_pps: '{{hostvars.dut_bond[datapath].bond_pps}}'

--- a/perf/roles/create-testpmd/tasks/main.yml
+++ b/perf/roles/create-testpmd/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Disable SELinux
+  selinux:
+    policy: targeted
+    state: permissive
+  tags: setup
+
+- name: create directory
+  file:
+    path: "/tmp/testpmd"
+    state: directory
+    owner: openvswitch
+    group: hugetlbfs
+  tags: setup
+
+- name: Remove Sockets
+  shell: "rm -f /tmp/sock*"
+  become: true
+  become_user: openvswitch
+  tags: setup
+
+- name: install testpmd systemd service
+  template:
+    src: testpmd.service
+    dest: /etc/systemd/system/testpmd.service
+    owner: openvswitch
+    group: hugetlbfs
+    mode: 0777
+  tags: install
+
+- name: Enable TestPMD service
+  systemd:
+    name: testpmd
+    enabled: yes
+    daemon_reload: true
+    state: started
+    force: true
+  tags: setup

--- a/perf/roles/create-testpmd/templates/testpmd.service
+++ b/perf/roles/create-testpmd/templates/testpmd.service
@@ -1,0 +1,22 @@
+# vim: ft=systemd
+[Unit]
+Description=DPDK TestPMD
+After=network.target
+
+[Service]
+Type=simple
+User=openvswitch
+Group=hugetlbfs
+ExecStartPre=rm -rf /tmp/sock*
+ExecStart=/usr/src/dpdk-stable-22.11.1/build/app/dpdk-testpmd \
+	-l {{vcpu_pinning.keys() | select('greaterthan',0)|join(",")}} --no-pci \
+	--vdev=net_virtio_user0,mac=00:11:22:33:44:10,path=/tmp/sock0,server=1,queues={{rxq}} \
+	--vdev=net_virtio_user1,mac=00:11:22:33:44:11,path=/tmp/sock1,server=1,queues={{rxq}} \
+	-n 4 -- --nb-cores={{vcpu_pinning|length - 2}} --rxq={{rxq}} --txq={{rxq}} --rxd={{rxd}} --txd={{rxd}}\
+{% for v in vhost_macs %}
+	--eth-peer={{loop.index0}},{{v.tgen}} \
+{% endfor %}
+	--forward-mode=mac --stats-period=5
+
+[Install]
+WantedBy=multi-user.target

--- a/perf/roles/ovs-bond/tasks/dpdk.yml
+++ b/perf/roles/ovs-bond/tasks/dpdk.yml
@@ -19,5 +19,5 @@
     bond_ports="{% for p in range(ports|length) %} port{{p}} {% endfor %}"
     ovs-vsctl add-bond br0 bond0 $bond_ports bond_mode={{bond_mode}} lacp=passive \
       other_config:bond-rebalance-interval={{bond_rebalance}} \
-     {% for p in ports %} -- set interface port{{loop.index0}} type=dpdk options:dpdk-devargs={{p}}{% endfor %}
+     {% for p in ports %} -- set interface port{{loop.index0}} type=dpdk options:dpdk-devargs={{p}} options:n_rxq={{n_rxq}}{% endfor %}
   tags: setup

--- a/perf/roles/ovs-mq-bond/defaults/main.yml
+++ b/perf/roles/ovs-mq-bond/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+pmd_auto_lb: "true"
+pmd_lb_load_threshold: 70
+pmd_rxq_assign: cycles

--- a/perf/roles/ovs-mq-bond/tasks/dpdk.yml
+++ b/perf/roles/ovs-mq-bond/tasks/dpdk.yml
@@ -1,0 +1,11 @@
+---
+
+- name: add port
+  command: >
+    ovs-vsctl add-port br0 vhost0 --
+      set interface vhost0 type=dpdkvhostuserclient options:vhost-server-path="/tmp/sock0" --
+      add-port br0 vhost1 --
+      set interface vhost1 type=dpdkvhostuserclient options:vhost-server-path="/tmp/sock1" --
+      set port vhost1 tag=201 --
+      set port vhost0 tag=201
+  tags: setup

--- a/perf/roles/ovs-mq-bond/tasks/main.yml
+++ b/perf/roles/ovs-mq-bond/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+- name: configure bridges
+  include_tasks: '{{datapath}}.yml'
+  tags: setup
+
+- name: initialize pmd-auto-lb
+  command: ovs-vsctl set open_vswitch . other_config:{{item}}
+  loop:
+    - 'pmd-auto-lb={{pmd_auto_lb}}'
+    - 'pmd-lb-load-threshold={{pmd_lb_load_threshold}}'
+    - 'pmd-rxq-assign={{pmd_rxq_assign}}'
+  tags: setup
+
+- name: restart vswitchd
+  service:
+    name: openvswitch.service
+    state: restarted
+  tags: setup

--- a/perf/roles/trex-ndr/defaults/main.yml
+++ b/perf/roles/trex-ndr/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-trex_dir: /tmp/trex-core
+trex_install_dir: /opt/trex
 output_file: /tmp/ndr-results.json
 profile: vlan
 vlan: 212

--- a/perf/roles/trex-ndr/tasks/main.yml
+++ b/perf/roles/trex-ndr/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: 'binary search: datapath={{datapath}} {{profile}}'
   command:
     cmd: >
-      ./ndr --stl -v --ports 0 1 --force-map --bi-dir --opt-bin-search
+      ./ndr --stl -v --ports 0 1 -t {{it_interval}} -ft {{first_it_time}} --force-map --bi-dir --opt-bin-search
         --profile {{profile}}_profile.py -o {{output_file}}
     chdir: '{{ trex_install_dir }}/'
   register: ndr_out

--- a/perf/roles/trex-ndr/tasks/main.yml
+++ b/perf/roles/trex-ndr/tasks/main.yml
@@ -3,14 +3,14 @@
 - name: upload traffic profile
   template:
     src: '{{profile}}_profile.py'
-    dest: '{{trex_dir}}/scripts/{{profile}}_profile.py'
+    dest: '{{ trex_install_dir }}/{{profile}}_profile.py'
 
 - name: 'binary search: datapath={{datapath}} {{profile}}'
   command:
     cmd: >
       ./ndr --stl -v --ports 0 1 --force-map --bi-dir --opt-bin-search
         --profile {{profile}}_profile.py -o {{output_file}}
-    chdir: '{{trex_dir}}/scripts'
+    chdir: '{{ trex_install_dir }}/'
   register: ndr_out
   tags: test
 

--- a/perf/roles/trex/defaults/main.yml
+++ b/perf/roles/trex/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
-trex_repo: https://github.com/rh-nfv-int/trex-core
 trex_tag: rhosp-playbooks
-trex_dir: /tmp/trex-core
 trex_opts: ''
+trex_release_url: "https://trex-tgn.cisco.com/trex/release"
+trex_version: 'v3.03'
+trex_install_dir: "/opt/trex"

--- a/perf/roles/trex/tasks/main.yml
+++ b/perf/roles/trex/tasks/main.yml
@@ -1,14 +1,9 @@
 ---
 
-- name: install build dependencies
+- name: install runtime dependencies
   dnf:
     name:
-      - gcc
-      - gcc-c++
-      - git
       - python3
-      - rdma-core-devel
-      - zlib-devel
     state: installed
   tags: install
 
@@ -17,21 +12,20 @@
   ignore_errors: true
   tags: setup
 
-- name: clone trex
-  git:
-    repo: '{{trex_repo}}'
-    dest: '{{trex_dir}}'
-    version: '{{trex_tag}}'
-    force: true
+- name: Create TRex install directory
+  file:
+    path: "{{ trex_install_dir }}"
+    state: directory
+    mode: "0755"
   tags: install
 
-- name: configure and build trex
-  command:
-    cmd: './b {{item}}'
-    chdir: '{{trex_dir}}/linux_dpdk'
-  loop:
-    - configure
-    - build
+- name: Download and Extract TRex release
+  unarchive:
+    src: "{{ trex_release_url }}/{{ trex_version }}.tar.gz"
+    dest: "{{ trex_install_dir }}"
+    remote_src: yes
+    extra_opts: --strip-components=1
+    validate_certs: no
   tags: install
 
 - name: upload trex configuration
@@ -42,8 +36,8 @@
 
 - name: start trex server
   shell:
-    cmd: 'nohup ./t-rex-64 {{trex_opts}} -i </dev/null >/tmp/trex.log 2>&1 &'
-    chdir: '{{trex_dir}}/scripts'
+    cmd: 'nohup ./t-rex-64 --cfg /etc/trex_cfg.yaml -i </dev/null >/tmp/trex.log 2>&1 &'
+    chdir: '{{ trex_install_dir }}/'
   tags: setup
 
 - name: wait for trex server


### PR DESCRIPTION
# Description: 

This pull request updated the installation process to make it more efficient. Downloading and building TRex takes a lot of time, hence we changed it to TRex cloning method with few additional modifications in TRex-NDR options.  This pull request also introduces some new roles for supporting multi-queue topology in OVS and virtio-user support for testPMD. Detailed description of changes is mentioned below. 

## Modifications: 
This pull request contains following modifications -  

- Modify TREX installation method to reduce execution time
- Add support for configuring iteration duration in TRex NDR for auto load balancing related tests
- Add a new role called create-testpmd, for virtio-user support
- Add support for multiple queues on DPDK ports 
- Created a new role, ovs-mq-bond, to support  the setup of OVS with multi-queue bonding.
- Add new ovs-mq-bond playbook which utilized the above mentioned role. 
